### PR TITLE
Fallback to ConvGRU rebuild on legacy Lambda slices

### DIFF
--- a/inference1/models.py
+++ b/inference1/models.py
@@ -14,6 +14,7 @@ from typing import Dict, Optional, Tuple
 
 import tensorflow as tf
 from tensorflow import keras as tfk
+from tensorflow.keras import utils as kutils
 
 import config as cfg
 
@@ -23,6 +24,20 @@ except Exception:  # pragma: no cover - environments without h5py
     h5py = None
 
 logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Legacy TF 2.x Lambda alias --------------------------------------------------
+# =============================================================================
+
+
+@kutils.register_keras_serializable(package="Legacy")
+class _LegacySlicingOpLambda(tfk.layers.Lambda):
+    """Compatibility wrapper for ``SlicingOpLambda`` serialized in TF 2.x."""
+
+
+# Ensure the alias is globally visible even outside explicit scopes.
+kutils.get_custom_objects().setdefault("SlicingOpLambda", _LegacySlicingOpLambda)
 
 # =============================================================================
 # Conv2DTranspose legacy "groups" key patch
@@ -242,6 +257,11 @@ def _convgru_custom_objects() -> Dict[str, object]:
         "weighted_mse": loss_fn,
         "csi": csi,
         "Conv2DTranspose": _LegacyConv2DTranspose,
+        # Historic checkpoints saved Lambda layers under the now-removed
+        # ``SlicingOpLambda`` name. Mapping the alias back to the standard
+        # Lambda layer lets Keras rebuild the graph without needing the
+        # original registration from TensorFlow 2.x.
+        "SlicingOpLambda": _LegacySlicingOpLambda,
         "reshape_and_stack": reshape_and_stack,
         "slice_to_n_steps": slice_to_n_steps,
         "slice_output_shape": slice_output_shape,
@@ -311,16 +331,23 @@ class ModelLoader:
             except TypeError as exc:
                 message = str(exc)
                 if (
-                    "ellipsis" in message.lower()
-                    and model_type is ModelType.CONVGRU
+                    model_type is ModelType.CONVGRU
                     and h5py is not None
                     and h5py.is_hdf5(load_path)
                 ):
-                    logger.info(
-                        "Detected ellipsis objects in legacy ConvGRU checkpoint; "
-                        "rebuilding architecture and loading weights manually."
-                    )
-                    return _rebuild_and_load_convgru_h5_weights(load_path)
+                    lower = message.lower()
+                    if "ellipsis" in lower:
+                        logger.info(
+                            "Detected ellipsis objects in legacy ConvGRU checkpoint; "
+                            "rebuilding architecture and loading weights manually."
+                        )
+                        return _rebuild_and_load_convgru_h5_weights(load_path)
+                    if "__operators__.getitem" in lower or "unsupported callable" in lower:
+                        logger.info(
+                            "Detected legacy Lambda slicing callable in ConvGRU checkpoint; "
+                            "rebuilding architecture and loading weights manually."
+                        )
+                        return _rebuild_and_load_convgru_h5_weights(load_path)
                 raise
 
         try:


### PR DESCRIPTION
## Summary
- rebuild the legacy ConvGRU architecture and load weights when load_model fails on historic Lambda slicing callables
- keep the existing ellipsis fallback while sharing the same conditional guard for ConvGRU HDF5 checkpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1772114ec8328a2437fa89331248c